### PR TITLE
Support optional params for oauth/token endpoint

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -45,12 +45,14 @@ module Auth0
       end
 
       # Logins using username/password
-      # @see https://auth0.com/docs/auth-api#!#post--oauth-ro
+      # @see https://auth0.com/docs/api/authentication#resource-owner-password
       # @param username [string] Username
       # @param password [string] User's password
-      # @param scope [string] Defaults to openid. Can be 'openid name email', 'openid offline_access'
-      # @param id_token [string] Token's id
-      # @param connection_name [string] Connection name. Works for database connections, passwordless connections,
+      # @param scope [string] Defaults to openid. Can be 'openid name email',
+      # 'openid offline_access'
+      # @param id_token [string] Deprecated, Token's id
+      # @param connection_name [string] Deprecated, Connection name. Works for
+      # database connections, passwordless connections.
       # Active Directory/LDAP, Windows Azure AD and ADF
       # @return [json] Returns the access token and id token
       def login(username, password, id_token = nil, connection_name = UP_AUTH, options = {})
@@ -61,12 +63,15 @@ module Auth0
           client_secret: @client_secret,
           username:      username,
           password:      password,
-          scope:         options.fetch(:scope, 'openid'),
           connection:    connection_name,
-          grant_type:    options.fetch(:grant_type, password),
           id_token:      id_token,
-          device:        options.fetch(:device, nil)
+          device:        options.fetch(:device, nil),
+          grant_type:    options.fetch(:grant_type, 'password'),
+          scope:         options.fetch(:scope, 'openid')
         }
+        request_params[:realm] = options[:realm] if options[:realm]
+        request_params[:audience] = options[:audience] if options[:audience]
+
         post('/oauth/token', request_params)
       end
 

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -57,17 +57,37 @@ describe Auth0::Api::AuthenticationEndpoints do
 
   context '.login' do
     it { expect(@instance).to respond_to(:login) }
+
     it 'is expected to make post to /oauth/token' do
       expect(@instance).to receive(:post).with(
         '/oauth/token',
         client_id: @instance.client_id,
         username: 'test@test.com',
         client_secret: @instance.client_secret,
-        password: 'password', scope: 'openid', connection: 'Username-Password-Authentication',
+        password: 'test123', scope: 'openid', connection: 'Username-Password-Authentication',
         grant_type: 'password', id_token: nil, device: nil
       )
-      @instance.login('test@test.com', 'password')
+      @instance.login('test@test.com', 'test123')
     end
+
+    it 'is expected to make post to /oauth/token with options' do
+      options = {
+        audience: 'test.auth0.com',
+        realm: 'Username-Password-Authentication'
+      }
+      expect(@instance).to receive(:post).with(
+        '/oauth/token',
+        client_id: @instance.client_id,
+        username: 'test@test.com',
+        client_secret: @instance.client_secret,
+        password: 'test123', scope: 'openid', connection: 'Username-Password-Authentication',
+        grant_type: 'password', id_token: nil, device: nil,
+        audience: 'test.auth0.com',
+        realm: 'Username-Password-Authentication'
+      )
+      @instance.login('test@test.com', 'test123', nil, 'Username-Password-Authentication', options)
+    end
+
     it { expect { @instance.login('', '') }.to raise_error 'Must supply a valid username' }
     it { expect { @instance.login('username', '') }.to raise_error 'Must supply a valid password' }
   end


### PR DESCRIPTION
Make sure we can pass `realm` and `audience` to the `/oauth/token` endpoint.